### PR TITLE
Audio wave progress color fix

### DIFF
--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -1946,7 +1946,7 @@ body .muted-hint a {
 }
 
 .audio-player__wave-placeholder {
-  background-color: var(--cyan);
+  background-color: var(--gray-shade-3);
 }
 
 .audio-player__waveform::before {


### PR DESCRIPTION
Both the played and unplayed parts of the audio wave had the same color, this should fix it. For some strange reason I can't preview this in my developer tools so I hope this won't need more tinkering.