### PR TITLE
theme patch for public profile page

### DIFF
--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -1573,7 +1573,7 @@ body .muted-hint a {
   background: var(--gray-shade-2);
 }
 
-.director__tag.active a{
+.directory__tag.active a{
   background: var(--cyan);
 }
 

--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -1539,6 +1539,10 @@ body .muted-hint a {
   profile directory
 */
 
+.endorsements-widget h4{
+  color:var(--gray-shade-5);
+}
+
 .filter-form {
   background: var(--gray-shade-2);
 }
@@ -1562,6 +1566,25 @@ body .muted-hint a {
 
 .directory__card__extra .account__header__content {
   border-bottom: 1px solid var(--gray-shade-5);
+}
+
+.directory__tag a {
+  border-color: var(--gray-shade-3);
+  background: var(--gray-shade-2);
+}
+
+.director__tag.active a{
+  background: var(--cyan);
+}
+
+.directory__tag a h4 .fa{
+  color: var(--gray-shade-5);
+}
+.directory__tag a h4 small{
+  color: var(--gray-shade-5);
+}
+.directory__tag a .trends__item__current{
+  color: var(--gray-shade-5);
 }
 
 .account__header__content, .accounts-table__count small {
@@ -1934,7 +1957,7 @@ body .muted-hint a {
 }
 
 /*
-  audio/video player styling 
+  audio/video player styling
 */
 
 .audio-player {


### PR DESCRIPTION
this pull request includes a few extra lines of CSS that help the Merveilles theme look consistent on public profile pages.

before:
<img width="315" alt="Screen Shot 2020-01-06 at 1 58 42 AM" src="https://user-images.githubusercontent.com/2532937/71801246-54ef1080-3028-11ea-94bb-1bfa79a9bfeb.png">
after:
<img width="315" alt="Screen Shot 2020-01-06 at 1 58 33 AM" src="https://user-images.githubusercontent.com/2532937/71801253-59b3c480-3028-11ea-9d44-403b35e0b723.png">

 