### PR TITLE
css & link tags

### DIFF
--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -1610,6 +1610,9 @@ body .muted-hint a {
 .directory__tag a .trends__item__current{
   color: var(--gray-shade-5);
 }
+.directory__tag.active a .trends__item__current{
+  color: var(--white);
+}
 
 .account__header__content, .accounts-table__count small {
   color: var(--gray-shade-9);

--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -1173,6 +1173,20 @@ a.status-card:hover {
   background: var(--gray-shade-1);
 }
 
+/* The two rulesets below address a background color gap
+   at the top of the public profile pages */
+.public-layout div.container{
+  padding-top:10px;
+}
+
+.public-layout div.container nav.header{
+  margin-top: 0px;
+}
+
+.public-layout .header p {
+  color: var(--cyan);
+}
+
 .public-layout .header .nav-button {
   background: var(--gray-shade-2);
 }
@@ -1581,6 +1595,12 @@ body .muted-hint a {
   background: var(--cyan);
 }
 
+.directory__tag a:active,
+.directory__tag a:focus,
+.directory__tag a:hover {
+    background: var(--gray-shade-3);
+}
+
 .directory__tag a h4 .fa{
   color: var(--gray-shade-5);
 }
@@ -1593,14 +1613,6 @@ body .muted-hint a {
 
 .account__header__content, .accounts-table__count small {
   color: var(--gray-shade-9);
-}
-
-.public-layout .header {
-  background: var(--black);
-}
-
-.public-layout .header p {
-  color: var(--cyan);
 }
 
 /*

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,6 +11,8 @@
       %link{ rel: 'dns-prefetch', href: storage_host }/
 
     %link{ rel: 'icon', href: favicon_path, type: 'image/x-icon' }/
+    %link{ rel: 'icon', href: 'mstile-150x150.png', type: 'image/png', sizes: '150x150' }
+    %link{ rel: 'icon', href: 'android-chrome-192x192.png', type: 'image/png', sizes: '192x192' }
     %link{ rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png' }/
     %link{ rel: 'mask-icon', href: '/mask-icon.svg', color: '#FFFFFF' }/
     %link{ rel: 'manifest', href: '/manifest.json' }/

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,8 +11,8 @@
       %link{ rel: 'dns-prefetch', href: storage_host }/
 
     %link{ rel: 'icon', href: favicon_path, type: 'image/x-icon' }/
-    %link{ rel: 'icon', href: 'mstile-150x150.png', type: 'image/png', sizes: '150x150' }
-    %link{ rel: 'icon', href: 'android-chrome-192x192.png', type: 'image/png', sizes: '192x192' }
+    %link{ rel: 'icon', href: '/mstile-150x150.png', type: 'image/png', sizes: '150x150' }
+    %link{ rel: 'icon', href: '/android-chrome-192x192.png', type: 'image/png', sizes: '192x192' }
     %link{ rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png' }/
     %link{ rel: 'mask-icon', href: '/mask-icon.svg', color: '#FFFFFF' }/
     %link{ rel: 'manifest', href: '/manifest.json' }/


### PR DESCRIPTION
This pull request includes

- css patch for background color on public profile layouts
<img width="266" alt="Screen Shot 2020-01-08 at 3 42 26 PM" src="https://user-images.githubusercontent.com/2532937/72014354-b16f4d00-322d-11ea-80b3-869b7c1f3759.png">
- css patch for featured hashtag hover background color (from mastodon #393f4f to merveilles gray 3)
<img width="312" alt="Screen Shot 2020-01-08 at 3 43 51 PM" src="https://user-images.githubusercontent.com/2532937/72014377-bd5b0f00-322d-11ea-9cb9-68b77dba4d44.png">
- link tags for web app on non-iOS devices / re: https://merveilles.town/@0xxg4/103448891532791121
