### PR TITLE
Removes sticky header on homepage

### DIFF
--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -1386,11 +1386,6 @@ a.status-card:hover {
   color: var(--cyan);
 }
 
-.public-layout .hero-widget {
-  position: sticky;
-  top: 0;
-}
-
 .account-role.admin {
   border: 2px solid white;
   background: transparent;


### PR DESCRIPTION
The position:sticky on here makes it frustrating for people to log in on mobile, since the very large header section overlays the username & password field. This fixes that.