### PR TITLE
set merveilles colorscheme for new visibility icon

### DIFF
--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -315,6 +315,10 @@ body {
   color: var(--gray-shade-5) !important;
 }
 
+.status__visibility-icon {
+  color: var(--gray-shade-5) !important;
+}
+
 .status__content p {
   color: var(--white) !important;
 }


### PR DESCRIPTION
this sets the color of the new visibility icon to be one of the shades we have defined, rather than the default blue from mastodon's theme

before
![image](https://user-images.githubusercontent.com/3862362/88711885-2302e000-d119-11ea-9526-28c5ac76496e.png)

after
![image](https://user-images.githubusercontent.com/3862362/88711866-1bdbd200-d119-11ea-8a19-1d3f6977dd61.png)
