### PR TITLE
Mobile header styles & other tweaks

### DIFF
--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -1031,6 +1031,10 @@ a.status-card:hover {
   color: var(--gray-shade-6);
 }
 
+.getting-started__wrapper .navigation-bar {
+  background-color: var(--gray-shade-2);
+}
+
 .column-subheading {
   background: var(--gray-shade-2);
   color: var(--gray-shade-6);
@@ -1065,6 +1069,10 @@ a.status-card:hover {
   background: none;
   height: 45px;
   overflow: hidden;
+}
+
+.tabs-bar__wrapper {
+  background-color: transparent;
 }
 
 .tabs-bar__link {
@@ -1522,6 +1530,20 @@ a.status-card:hover {
   color: var(--cyan);
 }
 
+.admin-wrapper .sidebar__toggle {
+  background-color: var(--gray-shade-3);
+
+  a:hover {
+    background-color: var(--gray-shade-4);
+  }
+}
+
+.admin-wrapper .sidebar__toggle__icon {
+  & > i {
+    color: var(--gray-shade-a);
+  }
+}
+
 .admin-wrapper .sidebar-wrapper {
   height: inherit;
   background: var(--black);
@@ -1928,6 +1950,18 @@ body .muted-hint a {
 .simple_form textarea:required:valid {
   background: var(--gray-shade-1);
   border-color: var(--cyan);
+}
+
+.poll .button.button-secondary:disabled {
+  background-color: var(--cyan);
+  cursor: pointer;
+  opacity: .5;
+}
+
+.poll .button.button-secondary {
+  background-color: var(--cyan);
+  cursor: pointer;
+  opacity: 1;
 }
 
 .poll__input {


### PR DESCRIPTION
Includes a number of style fixes:

- Implements poll style fixes that were manually included on the Admin panel (no visible changes)
- Removes color from mobile header & profile dropdown when viewing on mobile (see changes below)

<img width="454" alt="Screen Shot 2021-01-03 at 05 18 59" src="https://user-images.githubusercontent.com/3317766/103479656-1cd9f500-4d84-11eb-9aa3-830193ef12ae.png">

<img width="473" alt="Screen Shot 2021-01-03 at 05 19 10" src="https://user-images.githubusercontent.com/3317766/103479660-1f3c4f00-4d84-11eb-84c1-b6f3733398f6.png">

