### PR TITLE
Colors minor buttons on column headers light

### DIFF
--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -77,7 +77,7 @@ body {
 .column-header__button {
   background: var(--gray-shade-3) !important;
   margin: 0 !important;
-  color: var(--gray-shade-1) !important;
+  color: var(--gray-shade-a) !important;
 }
 
 .column-header__button:hover {


### PR DESCRIPTION
I'd forgotten over the last couple of years that Mastodon has a way to mark all notifications as read.

https://merveilles.town/@akkartik/108080475076325407

![](https://assets.merveilles.town/media_attachments/files/108/080/621/491/171/246/original/a30f0373fbbc3dac.png)

This commit follows the other themes and switches settings buttons on column headers to be lighter than the background rather than darker.