### PR TITLE
Theme updates for tidbits around the instance

### DIFF
--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -2334,3 +2334,106 @@ a.table-action-link {
 .dashboard__counters__label {
   color: var(--gray-shade-a);
 }
+
+.account__header__bio .account__header__fields {
+  border-top: 1px solid var(--gray-shade-3);
+}
+
+.account__header__bio .account__header__joined {
+  color: var(--gray-shade-8);
+}
+
+.simple_form .hint a {
+  color: var(--cyan);
+}
+
+.simple_form .input.boolean label.checkbox {
+  accent-color: var(--cyan);
+}
+
+.announcements-list, .applications-list__item {
+  border: 1px solid var(--gray-shade-5);
+}
+
+.applications-list__item {
+  background: var(--gray-shade-1-5);
+}
+
+.permissions-list__item__text__type {
+  color: var(--cyan-light);
+}
+
+.announcements-list__item__title {
+  color: var(--gray-shade-c);
+}
+
+.permissions-list__item {
+  color: var(--gray-shade-e);
+  border-bottom: 1px solid var(--gray-shade-5);
+  
+}
+
+.empty-column-indicator, .error-column, .follow_requests-unlocked_explanation {
+  color: var(--gray-shade-e);
+}
+
+.empty-column-indicator a, .error-column a, .follow_requests-unlocked_explanation a {
+  color: var(--cyan);
+}
+
+.scrollable .account-card {
+  background: var(--gray-shade-1);
+}
+
+.scrollable .account-card__bio::after {
+  background: linear-gradient(270deg,var(--gray-shade-1),transparent);
+}
+
+.account-card__bio a {
+  color: var(--gray-shade-c);
+  
+}
+
+.account-card__counters__item small {
+  color: var(--gray-shade-c);
+}
+
+.keyboard-shortcuts kbd {
+  background-color: var(--black);
+  border: 1px solid var(--cyan);
+}
+
+.permissions-list__item {
+  color: var(--white);
+  border-bottom: 1px solid var(--gray-shade-5);
+}
+
+.permissions-list__item:last-child {
+  padding-bottom: 12px;
+}
+
+.permissions-list__item__text__type {
+  color: var(--cyan);
+}
+
+.oauth-prompt p {
+  color: var(--gray-shade-e);
+}
+
+.follow-prompt strong, .oauth-prompt strong {
+  color: var(--cyan);}
+
+.oauth-prompt h3 {
+  color: var(--gray-shade-e);
+}
+
+.oauth-prompt .permissions-list {
+  border: 1px solid var(--gray-shade-5);
+  background: var(--gray-shade-5);
+}
+
+.account-header .name {
+  flex: 1 1 auto;
+  color: var(--gray-shade-e);
+  width: calc(100% - 90px);
+}

--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -2447,3 +2447,7 @@ a.table-action-link {
 .simple_form .input.radio_buttons .radio {
   accent-color: var(--cyan);
 }
+
+.follow_requests-unlocked_explanation {
+  background: var(--gray-shade-1);
+}

--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -2433,7 +2433,17 @@ a.table-action-link {
 }
 
 .account-header .name {
-  flex: 1 1 auto;
   color: var(--gray-shade-e);
-  width: calc(100% - 90px);
+}
+
+.upload-progress__tracker {
+  background: var(--cyan);
+}
+
+.upload-progress__backdrop {
+  background: var(--gray-shade-2);
+}
+
+.simple_form .input.radio_buttons .radio {
+  accent-color: var(--cyan);
 }

--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -2451,3 +2451,20 @@ a.table-action-link {
 .follow_requests-unlocked_explanation {
   background: var(--gray-shade-1);
 }
+
+.account__header__account-note label {
+  color: var(--gray-shade-a)
+}
+
+.account__header__account-note textarea {
+  border: 2px solid var(--gray-shade-4);
+}
+
+.account__header__account-note textarea::placeholder {
+  color: var(--gray-shade-a);
+  opacity: 1;
+}
+
+.account__header__account-note textarea:focus {
+  background: var(--gray-shade-1);
+}


### PR DESCRIPTION
These commits change several colors on lesser used pages like the OAuth authorization page, the profile directory and the keyboard shortcuts page to bring them in line with the rest of the instances theming. Also changed the color of the media upload graphic to --cyan, same again for checkboxes and radio buttons on the settings pages.

Themed and added a border to the notes section on user profiles to make it more obvious that the area can be clicked after it is filled out.