### PR TITLE
Ensure header image is fully displayed

### DIFF
--- a/app/javascript/styles/merveilles.scss
+++ b/app/javascript/styles/merveilles.scss
@@ -752,10 +752,6 @@ a.status-card:hover {
 }
 
 .account__header {
-  background-color: var(--black);
-}
-
-.account__header > div {
   background: var(--gray-shade-2);
 }
 


### PR DESCRIPTION
Hello!

Here's a small CSS tweak to ensure that the header image in a user profile is correctly displayed.

Before:
![CleanShot 2025-03-29 at 17 47 52@2x](https://github.com/user-attachments/assets/b6532119-79f6-4118-8200-55a04a220344)

After:
![CleanShot 2025-03-29 at 17 48 18@2x](https://github.com/user-attachments/assets/8e097575-3d84-4151-a628-6f5de46558d4)


Please let me know if anything needs to change here!

Gosha